### PR TITLE
fix: localize the class and pass the external validator AdminUpdateUserRequest to register it to be used

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,7 +19,8 @@ class AdminPostProductsProductReq extends MedusaAdminPostProductsProductReq {
 	shipping_options?: string[];
 }
 
-export class AdminUpdateUserRequest extends MedusaAdminUpdateUserRequest {
+// change this to a local class declaration
+class AdminUpdateUserRequest extends MedusaAdminUpdateUserRequest {
 	@IsEnum(UserStatus)
 	@IsOptional()
 	status?: UserStatus;
@@ -27,3 +28,8 @@ export class AdminUpdateUserRequest extends MedusaAdminUpdateUserRequest {
 
 registerOverriddenValidators(AdminPostProductsReq);
 registerOverriddenValidators(AdminPostProductsProductReq);
+/**
+ * We have to register the external validator AdminUpdateUserRequest as an
+ * override for the vendor update request so the new field status gets recognized
+*/
+registerOverriddenValidators(AdminUpdateUserRequest);


### PR DESCRIPTION
This PR fixes the issue where the custom validator for `AdminUpdateUserRequest` was not being properly registered, which caused validation errors when updating user statuses in the admin UI. The fix involves correctly registering the overridden validator to ensure the `status` field is recognized and validated. The issue was mentioned in #30. The fix was to register the `AdminUpdateUserRequest` using `registerOverriddenValidators` to replace the core validator.

Without registering the custom `AdminUpdateUserRequest`, Medusa's default validation kicks in and fails to recognize the custom `status` field. This results in errors like:

```
{"type":"invalid_data","message":"property status should not exist"}
```

So to fix this, we have to register the custom validator as documented [here](https://docs.medusajs.com/development/api-routes/extend-validator). This will ensure that our extended request (with the `status` field) is properly validated. I tested it and the status field is now validated correctly when updating a user. Further information on extending and registering custom validators can be found [in the Medusa docs](https://docs.medusajs.com/development/api-routes/extend-validator).

#### Example Demonstration

[25af840d-8aba-4972-a0ef-2fa097c5d249.webm](https://github.com/user-attachments/assets/a9f46e1e-5f76-48f8-9c62-0f82b7ff4b01)

[a33ea09f-368a-493a-aa02-02274c4ae79b.webm](https://github.com/user-attachments/assets/2e012e13-2d3a-46ce-aa5e-b6063c9b4847)